### PR TITLE
fix: Don't crash if queryeer config don't load

### DIFF
--- a/queryeer-api/src/main/java/com/queryeer/api/component/DialogUtils.java
+++ b/queryeer-api/src/main/java/com/queryeer/api/component/DialogUtils.java
@@ -141,6 +141,10 @@ public final class DialogUtils
     {
         Window activeWindow = FocusManager.getCurrentManager()
                 .getActiveWindow();
+        if (activeWindow == null)
+        {
+            return;
+        }
 
         // Find first window in hierarchy that has icon images else use null
         List<Image> iconImages = activeWindow.getIconImages();

--- a/queryeer-catalog/src/main/resources/se/kuseman/payloadbuilder/catalog/jdbc/com.queryeer.jdbc.QueryActions.cfg
+++ b/queryeer-catalog/src/main/resources/se/kuseman/payloadbuilder/catalog/jdbc/com.queryeer.jdbc.QueryActions.cfg
@@ -144,6 +144,12 @@
             "TRIGGER"
           ],
           "output": "TEXT",
+          "actionTargets": [
+            "NAVIGATION_TREE"
+          ],
+          "actionTypes": [
+            "CONTEXT_MENU"
+          ],
           "queryName": "",
           "overrides": [
             {
@@ -160,6 +166,12 @@
             "TRIGGER"
           ],
           "output": "CLIPBOARD",
+          "actionTargets": [
+            "NAVIGATION_TREE"
+          ],
+          "actionTypes": [
+            "CONTEXT_MENU"
+          ],
           "queryName": "",
           "overrides": [
             {
@@ -176,6 +188,12 @@
             "TRIGGER"
           ],
           "output": "NEW_QUERY",
+          "actionTargets": [
+            "NAVIGATION_TREE"
+          ],
+          "actionTypes": [
+            "CONTEXT_MENU"
+          ],
           "queryName": "",
           "overrides": [
             {

--- a/queryeer-ide/src/main/java/com/queryeer/Config.java
+++ b/queryeer-ide/src/main/java/com/queryeer/Config.java
@@ -84,9 +84,16 @@ class Config implements IConfig
         }
         else
         {
-            // Read existing config
-            MAPPER.readerForUpdating(this)
-                    .readValue(file);
+            try
+            {
+                // Read existing config
+                MAPPER.readerForUpdating(this)
+                        .readValue(file);
+            }
+            catch (IOException e)
+            {
+                LOGGER.error("Error loading queryeer config", e);
+            }
         }
 
         sessionFile = new File(etcFolder, SESSION);

--- a/queryeer-ide/src/main/java/com/queryeer/QueryeerController.java
+++ b/queryeer-ide/src/main/java/com/queryeer/QueryeerController.java
@@ -602,8 +602,11 @@ class QueryeerController implements PropertyChangeListener
 
     private void showOptionsAction(Class<? extends IConfigurable> configurableToSelect)
     {
-        optionsDialog.setSelectedConfigurable(configurableToSelect);
-        optionsDialog.setVisible(true);
+        SwingUtilities.invokeLater(() ->
+        {
+            optionsDialog.setSelectedConfigurable(configurableToSelect);
+            optionsDialog.setVisible(true);
+        });
     }
 
     private void toggleResultAction()

--- a/queryeer-ide/src/main/java/com/queryeer/QueryeerModel.java
+++ b/queryeer-ide/src/main/java/com/queryeer/QueryeerModel.java
@@ -182,7 +182,9 @@ class QueryeerModel
         {
             index = files.size() - 1;
         }
-        selectedFile = files.get(index);
+        selectedFile = index >= 0
+                && index < files.size() ? files.get(index)
+                        : null;
 
         setSelectedFile(selectedFile);
     }

--- a/queryeer-ide/src/main/java/com/queryeer/editor/EditorFactory.java
+++ b/queryeer-ide/src/main/java/com/queryeer/editor/EditorFactory.java
@@ -49,7 +49,8 @@ class EditorFactory implements IEditorFactory
 
     private void installQueryShortcuts(IQueryEngine.IState engineState, TextEditor editor)
     {
-        ActionMap actionMap = editor.getActionMap();
+        ActionMap actionMap = editor.getComponent()
+                .getActionMap();
         // Create actions for each query shortcut
         for (int i = 0; i < TextEditorQueryShortcutConfigurable.QUERY_SHORTCUT_COUNT; i++)
         {
@@ -64,7 +65,8 @@ class EditorFactory implements IEditorFactory
 
     private void bindQueryShortcuts(TextEditor editor)
     {
-        InputMap inputMap = editor.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+        InputMap inputMap = editor.getComponent()
+                .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
         inputMap.clear();
 
         for (int i = 0; i < TextEditorQueryShortcutConfigurable.QUERY_SHORTCUT_COUNT; i++)


### PR DESCRIPTION
fix: Fix crash when the last file was closed
fix: Run show options dialog from event on EDT
fix: TextEditor should not inherit panel due to clash with addPropertyChangeListener method that causes NPE on some LAF:s
fix: Guard against NPE when setting image icons on dialogs fix: Fix broken default config of JDBC query actions where Definition submenu did not appear