### PR TITLE
feat: Add support for OutputComponents to implement an extended Outpu…

### DIFF
--- a/queryeer-api/src/main/java/com/queryeer/api/extensions/engine/IQueryEngine.java
+++ b/queryeer-api/src/main/java/com/queryeer/api/extensions/engine/IQueryEngine.java
@@ -57,7 +57,7 @@ public interface IQueryEngine extends IExtension
      * Execute query NOTE! Is executed in a threaded fashion
      *
      * @param queryFile The query file "owning" the execution
-     * @param writer Writer that should be used for the result
+     * @param writer Writer that should be used for the result. {@see QueryeerOutputWriter}
      * @param query Query to execute. This is the current {@link IQueryFile}'s {@link IEditor}'s value. NOTE! This value is not necessarily a String but can also be a custom query object sent by
      * {@link ExecuteQueryEvent}..
      */

--- a/queryeer-api/src/main/java/com/queryeer/api/extensions/output/QueryeerOutputWriter.java
+++ b/queryeer-api/src/main/java/com/queryeer/api/extensions/output/QueryeerOutputWriter.java
@@ -1,0 +1,25 @@
+package com.queryeer.api.extensions.output;
+
+import static java.util.Collections.emptyMap;
+
+import java.util.Map;
+
+import se.kuseman.payloadbuilder.api.OutputWriter;
+
+/**
+ * An extension of PLB's {@link OutputWriter} that has some extensions to make queryeer more rich. Various {@link IOutputComponent}'s has support for this writer.
+ */
+public interface QueryeerOutputWriter extends OutputWriter
+{
+    /** Timestamp metadata key. If not present in metadata it will automatically be added by queryeer. */
+    public static final String METADATA_TIMESTAMP = "Timestamp";
+
+    /** Init result with columns and meta data about current result. Ie. can be JDBC specifics like current database/cconnection or similar. */
+    void initResult(String[] columns, Map<String, Object> resultMetaData);
+
+    @Override
+    default void initResult(String[] columns)
+    {
+        initResult(columns, emptyMap());
+    }
+}

--- a/queryeer-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/ConnectionState.java
+++ b/queryeer-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/ConnectionState.java
@@ -164,7 +164,7 @@ class ConnectionState implements Closeable
         return abort;
     }
 
-    void afterQuery()
+    void reset()
     {
         abort = false;
         currentStatement = null;

--- a/queryeer-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/JdbcEngineQuickPropertiesComponent.java
+++ b/queryeer-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/JdbcEngineQuickPropertiesComponent.java
@@ -1,0 +1,398 @@
+package se.kuseman.payloadbuilder.catalog.jdbc;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Window;
+import java.util.Objects;
+
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import javax.swing.tree.TreeSelectionModel;
+
+import org.apache.commons.io.IOUtils;
+
+import com.queryeer.api.IQueryFile;
+import com.queryeer.api.QueryFileMetaData;
+import com.queryeer.api.component.AutoCompletionComboBox;
+import com.queryeer.api.component.QueryeerTree;
+import com.queryeer.api.component.QueryeerTree.RegularNode;
+import com.queryeer.api.editor.ITextEditor;
+import com.queryeer.api.event.NewQueryFileEvent;
+import com.queryeer.api.event.ShowOptionsEvent;
+import com.queryeer.api.service.IEventBus;
+import com.queryeer.api.service.IQueryFileProvider;
+
+import se.kuseman.payloadbuilder.catalog.jdbc.JdbcConnectionsTreeModel.ConnectionNode;
+import se.kuseman.payloadbuilder.catalog.jdbc.JdbcConnectionsTreeModel.DatabaseNode;
+import se.kuseman.payloadbuilder.catalog.jdbc.dialect.DatabaseProvider;
+import se.kuseman.payloadbuilder.catalog.jdbc.dialect.JdbcDatabase;
+
+/** Quick properties for JdbcEngine. */
+class JdbcEngineQuickPropertiesComponent extends JPanel
+{
+    private final JdbcQueryEngine queryEngine;
+    private final IQueryFileProvider queryFileProvider;
+    private final JdbcConnectionsModel connectionsModel;
+    private final IEventBus eventBus;
+    private final CatalogCrawlService crawlService;
+
+    private final JTextField currentConnection;
+    private final JComboBox<String> databases;
+    private final DefaultComboBoxModel<String> databasesModel;
+    private boolean suppressEvents = false;
+
+    //@formatter:off
+    JdbcEngineQuickPropertiesComponent(
+            JdbcQueryEngine queryEngine,
+            Icons icons,
+            IQueryFileProvider queryFileProvider,
+            JdbcConnectionsModel connectionsModel,
+            IEventBus eventBus,
+            DatabaseProvider databaseProvider,
+            CatalogCrawlService crawlService)
+    {
+        //@formatter:on
+        this.queryEngine = queryEngine;
+        this.queryFileProvider = queryFileProvider;
+        this.connectionsModel = connectionsModel;
+        this.eventBus = eventBus;
+        this.crawlService = crawlService;
+
+        setLayout(new GridBagLayout());
+
+        databases = new JComboBox<>();
+        databases.setRenderer(new DefaultListCellRenderer()
+        {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus)
+            {
+                JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                label.setIcon(icons.database);
+                return label;
+            }
+        });
+        databases.setMaximumRowCount(40);
+        databases.addItemListener(l ->
+        {
+            if (suppressEvents)
+            {
+                return;
+            }
+            IQueryFile currentFile = queryFileProvider.getCurrentFile();
+            if (l.getItem() instanceof String
+                    && currentFile != null)
+            {
+                JdbcEngineState engineState = currentFile.getEngineState();
+                ConnectionState state = engineState.connectionState;
+
+                if (state != null)
+                {
+                    // TODO: Do not run this on EDT
+                    state.setDatabaseOnConnection((String) l.getItem(), currentFile);
+                    setStatus(currentFile, state);
+                }
+
+                engineState.resetParser();
+
+                // Re-parse content when we switch database
+                if (currentFile.getEditor() instanceof ITextEditor textEditor)
+                {
+                    textEditor.parse();
+                }
+            }
+        });
+
+        databases.setEditable(false);
+        databasesModel = new DefaultComboBoxModel<>();
+        databases.setModel(databasesModel);
+        AutoCompletionComboBox.enable(databases);
+
+        currentConnection = new JTextField("");
+        currentConnection.setEditable(false);
+
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.insets = new Insets(0, 0, 2, 2);
+        JPanel currentConnectionPanel = new JPanel(new GridBagLayout());
+        currentConnectionPanel.add(new JLabel("Server:")
+        {
+            {
+                setFont(getFont().deriveFont(Font.BOLD));
+            }
+        }, gbc);
+
+        gbc = new GridBagConstraints();
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        gbc.weightx = 1.0d;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.anchor = GridBagConstraints.WEST;
+        currentConnectionPanel.add(currentConnection, gbc);
+
+        gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.gridwidth = 2;
+        gbc.weightx = 1.0d;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.anchor = GridBagConstraints.WEST;
+        add(currentConnectionPanel, gbc);
+
+        gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.weightx = 1.0d;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.anchor = GridBagConstraints.WEST;
+
+        JPanel databasesPanel = new JPanel(new GridBagLayout());
+        databasesPanel.add(databases, gbc);
+
+        JButton changeConnection = new JButton();
+        changeConnection.setMaximumSize(new Dimension(18, 18));
+        changeConnection.setMinimumSize(new Dimension(18, 18));
+        changeConnection.setPreferredSize(new Dimension(18, 18));
+        changeConnection.setIcon(icons.plug);
+        changeConnection.setToolTipText("Change Connection");
+
+        gbc = new GridBagConstraints();
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.anchor = GridBagConstraints.WEST;
+        databasesPanel.add(changeConnection, gbc);
+
+        gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 1;
+        gbc.gridwidth = 2;
+        gbc.weightx = 1.0d;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.anchor = GridBagConstraints.WEST;
+        add(databasesPanel, gbc);
+
+        changeConnection.addActionListener(l ->
+        {
+            IQueryFile currentFile = queryFileProvider.getCurrentFile();
+            if (currentFile == null)
+            {
+                return;
+            }
+
+            if (connectionsModel.getSize() == 0)
+            {
+                eventBus.publish(new ShowOptionsEvent(JdbcConnectionsConfigurable.class));
+                return;
+            }
+
+            Object[] values = connectionsModel.getConnections()
+                    .toArray();
+
+            Window activeWindow = javax.swing.FocusManager.getCurrentManager()
+                    .getActiveWindow();
+            JdbcConnection result = (JdbcConnection) JOptionPane.showInputDialog(activeWindow, "Connection", "Change Connection", JOptionPane.QUESTION_MESSAGE, null, values, values[0]);
+
+            if (result != null
+                    && connectionsModel.prepare(result, false))
+            {
+
+                JdbcDatabase jdbcDatabase = databaseProvider.getDatabase(result.getJdbcURL());
+                JdbcEngineState engineState = currentFile.getEngineState();
+                ConnectionState state = engineState.connectionState;
+
+                // Close old state if any
+                if (state != null)
+                {
+                    JdbcQueryEngine.EXECUTOR.execute(() -> IOUtils.closeQuietly(state));
+                }
+
+                // Create new state
+                ConnectionState newState = new ConnectionState(result, jdbcDatabase);
+                engineState.setConnectionState(newState);
+                queryEngine.focus(currentFile);
+                // Lazy load databases
+                loadConnectionMetaData(engineState);
+            }
+        });
+
+        JdbcConnectionsTreeModel connectionsTreeModel = new JdbcConnectionsTreeModel(connectionsModel, icons, databaseProvider, node -> newQuery(node));
+        QueryeerTree.QueryeerTreeModel treeModel = new QueryeerTree.QueryeerTreeModel(connectionsTreeModel);
+        connectionsModel.addListDataListener(new ListDataListener()
+        {
+            @Override
+            public void intervalRemoved(ListDataEvent e)
+            {
+            }
+
+            @Override
+            public void intervalAdded(ListDataEvent e)
+            {
+            }
+
+            @Override
+            public void contentsChanged(ListDataEvent e)
+            {
+                // Reload root when connections model changes
+                treeModel.resetRoot();
+            }
+        });
+
+        QueryeerTree tree = new QueryeerTree(treeModel);
+        tree.getSelectionModel()
+                .setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
+        tree.setHyperLinksEnabled(true);
+
+        gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 2;
+        gbc.gridwidth = 2;
+        gbc.weightx = 1.0d;
+        gbc.weighty = 1.0d;
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.fill = GridBagConstraints.BOTH;
+        add(new JScrollPane(tree), gbc);
+        setPreferredSize(new Dimension(240, 75));
+    }
+
+    private void newQuery(RegularNode node)
+    {
+        ConnectionState state = null;
+        if (node instanceof ConnectionNode cnode)
+        {
+            state = cnode.createState();
+        }
+        else if (node instanceof DatabaseNode dnode)
+        {
+            state = dnode.createState();
+        }
+
+        if (state != null
+                && connectionsModel.prepare(state.getJdbcConnection(), false))
+        {
+            JdbcEngineState engineState = new JdbcEngineState(queryEngine, state);
+            eventBus.publish(new NewQueryFileEvent(queryEngine, engineState, null, false, null));
+            // Lazy load databases
+            loadConnectionMetaData(engineState);
+        }
+    }
+
+    private void loadConnectionMetaData(JdbcEngineState state)
+    {
+        if (state.getJdbcConnection()
+                .getDatabases() == null)
+        {
+            JdbcQueryEngine.EXECUTOR.execute(() ->
+            {
+                connectionsModel.getDatabases(state.getJdbcConnection(), true, false);
+
+                IQueryFile currentFile = queryFileProvider.getCurrentFile();
+                if (currentFile != null)
+                {
+                    JdbcEngineState currentEngineState = currentFile.getEngineState();
+                    ConnectionState currentState = currentEngineState.connectionState;
+                    // If the current file is the same as the one we loaded databases on then re-focus it
+                    if (currentState != null
+                            && currentState.getJdbcConnection() == state.getJdbcConnection())
+                    {
+                        SwingUtilities.invokeLater(() -> focus(currentFile));
+                    }
+                }
+            });
+        }
+        if (state.getDatabase() != null)
+        {
+            crawlService.getCatalog(state, state.getDatabase());
+        }
+    }
+
+    void setSelectedDatabase(ConnectionState state)
+    {
+        databasesModel.setSelectedItem(state.getDatabase());
+    }
+
+    void setStatus(IQueryFile file, ConnectionState state)
+    {
+        String connectionInfo = "<html><font color=\"%s\"><b>%s: %s / %s%s / %s</b></font>".formatted(Objects.toString(state.getJdbcConnection()
+                .getColor(), "#000000"), state.getJdbcDatabase()
+                        .getSessionKeyword(),
+                isBlank(state.getSessionId()) ? "Not connected"
+                        : state.getSessionId(),
+                state.getJdbcConnection()
+                        .getName(),
+                (!isBlank(state.getDatabase()) ? " / " + state.getDatabase()
+                        : ""),
+                state.getJdbcConnection()
+                        .getUsername());
+
+        file.setMetaData(new QueryFileMetaData(connectionInfo, state.getSessionId()));
+    }
+
+    void focus(IQueryFile queryFile)
+    {
+        suppressEvents = true;
+
+        try
+        {
+            databasesModel.removeAllElements();
+            databases.setEnabled(false);
+            JdbcEngineState engineState = queryFile.getEngineState();
+            ConnectionState state = engineState.connectionState;
+            if (currentConnection != null)
+            {
+                currentConnection.setText(state != null ? state.getJdbcConnection()
+                        .getName()
+                        : "");
+            }
+            if (state != null)
+            {
+                // Force a reparse when we focus a new file
+                if (queryFile.getEditor() instanceof ITextEditor textEditor)
+                {
+                    if (textEditor.getEditorKit() instanceof JdbcTextEditorKit kit)
+                    {
+                        kit.updateActionStatuses();
+                    }
+                    textEditor.parse();
+                }
+
+                if (state.getJdbcConnection()
+                        .getDatabases() != null)
+                {
+                    databasesModel.addAll(state.getJdbcConnection()
+                            .getDatabases());
+                    databasesModel.setSelectedItem(state.getDatabase());
+                    databases.setEnabled(true);
+                }
+
+                setStatus(queryFile, state);
+            }
+            else
+            {
+                queryFile.setMetaData(new QueryFileMetaData("<html><font color=\"#000000\"><b>Not connected</b></font></html>", ""));
+            }
+        }
+        finally
+        {
+            suppressEvents = false;
+        }
+    }
+}

--- a/queryeer-ide/src/main/java/com/queryeer/Constants.java
+++ b/queryeer-ide/src/main/java/com/queryeer/Constants.java
@@ -1,13 +1,9 @@
 package com.queryeer;
 
-import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toList;
-
 import java.awt.Dimension;
 import java.awt.Image;
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
 
 import javax.imageio.ImageIO;
 import javax.swing.Icon;
@@ -17,8 +13,12 @@ import org.kordamp.ikonli.fontawesome.FontAwesome;
 import org.kordamp.ikonli.swing.FontIcon;
 
 /** Constants in Queryeer */
-public interface Constants
+public class Constants
 {
+    private Constants()
+    {
+    }
+
     public static final Dimension DEFAULT_DIALOG_SIZE = new Dimension(1000, 800);
     public static final Icon CHECK_CIRCLE_ICON = FontIcon.of(FontAwesome.CHECK_CIRCLE);
     public static final Icon PLAY_ICON = FontIcon.of(FontAwesome.PLAY);
@@ -36,23 +36,29 @@ public interface Constants
     static final Icon ARROWS_H = FontIcon.of(FontAwesome.ARROWS_H);
     static final Icon PARAGRAPH = FontIcon.of(FontAwesome.PARAGRAPH);
     static final Icon EDIT = FontIcon.of(FontAwesome.EDIT);
-    static final Icon COG = FontIcon.of(FontAwesome.COG);
+    public static final Icon COG = FontIcon.of(FontAwesome.COG);
     public static final int SCROLLBAR_WIDTH = ((Integer) UIManager.get("ScrollBar.width")).intValue();
-    public static final List<? extends Image> APPLICATION_ICONS = asList("icons8-database-administrator-48.png", "icons8-database-administrator-96.png").stream()
-            .map(name -> QueryeerView.class.getResource("/icons/" + name))
-            .map(stream ->
-            {
-                try
-                {
-                    return ImageIO.read(stream);
-                }
-                catch (IOException e)
-                {
-                    e.printStackTrace();
-                    return null;
-                }
-            })
-            .filter(Objects::nonNull)
-            .collect(toList());
 
+    public static final Image APPLICATION_ICON_48;
+    public static final Image APPLICATION_ICON_96;
+    public static final List<? extends Image> APPLICATION_ICONS;
+
+    static
+    {
+        Image icon48 = null;
+        Image icon96 = null;
+
+        try
+        {
+            icon48 = ImageIO.read(QueryeerView.class.getResource("/icons/icons8-database-administrator-48.png"));
+            icon96 = ImageIO.read(QueryeerView.class.getResource("/icons/icons8-database-administrator-96.png"));
+        }
+        catch (IOException e)
+        {
+            Main.LOGGER.error("Error reading application icons", e);
+        }
+        APPLICATION_ICON_48 = icon48;
+        APPLICATION_ICON_96 = icon96;
+        APPLICATION_ICONS = List.of(icon48, icon96);
+    }
 }

--- a/queryeer-ide/src/main/java/com/queryeer/Main.java
+++ b/queryeer-ide/src/main/java/com/queryeer/Main.java
@@ -2,6 +2,8 @@ package com.queryeer;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import java.awt.Taskbar;
+import java.awt.Taskbar.Feature;
 import java.io.File;
 import java.io.IOException;
 
@@ -27,13 +29,14 @@ import com.queryeer.api.service.ITemplateService;
 /** Main of Queryeer */
 public class Main
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
 
     /** Main */
     public static void main(String[] args) throws Exception
     {
         /* Trap CMD-q on OSX to properly run shutdown hooks etc. */
         System.setProperty("apple.eawt.quitStrategy", "CLOSE_ALL_WINDOWS");
+        System.setProperty("apple.awt.application.name", "Queryeer");
 
         /* Set mnemontics for option pane */
         UIManager.put("OptionPane.yesButtonMnemonic", "89");
@@ -82,6 +85,7 @@ public class Main
         // Start all Swing applications on the EDT.
         SwingUtilities.invokeLater(() ->
         {
+            setTaskBarInfo();
             if (System.getProperty("devEnv") != null)
             {
                 RepaintManager.setCurrentManager(new CheckThreadViolationRepaintManager());
@@ -89,6 +93,21 @@ public class Main
             controller.getView()
                     .setVisible(true);
         });
+    }
+
+    private static void setTaskBarInfo()
+    {
+        if (!Taskbar.isTaskbarSupported())
+        {
+            return;
+        }
+
+        if (Taskbar.getTaskbar()
+                .isSupported(Feature.ICON_IMAGE))
+        {
+            Taskbar.getTaskbar()
+                    .setIconImage(Constants.APPLICATION_ICON_48);
+        }
     }
 
     private static void wire(File etcFolder, File backupFolder, ServiceLoader serviceLoader) throws IOException, InstantiationException, IllegalAccessException

--- a/queryeer-ide/src/main/java/com/queryeer/output/table/TableOutputComponent.java
+++ b/queryeer-ide/src/main/java/com/queryeer/output/table/TableOutputComponent.java
@@ -1,11 +1,15 @@
 package com.queryeer.output.table;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
@@ -17,6 +21,7 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import javax.swing.AbstractAction;
@@ -25,6 +30,7 @@ import javax.swing.BorderFactory;
 import javax.swing.DefaultRowSorter;
 import javax.swing.Icon;
 import javax.swing.InputMap;
+import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JMenu;
@@ -36,7 +42,7 @@ import javax.swing.JPopupMenu.Separator;
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
-import javax.swing.JTable;
+import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.RowFilter;
 import javax.swing.SwingUtilities;
@@ -44,6 +50,7 @@ import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import javax.swing.event.TableModelEvent;
 
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.fife.rsta.ui.search.FindDialog;
 import org.fife.rsta.ui.search.SearchEvent;
@@ -60,6 +67,7 @@ import com.queryeer.api.extensions.output.table.ITableContextMenuAction;
 import com.queryeer.api.extensions.output.table.ITableContextMenuActionFactory;
 import com.queryeer.api.extensions.output.table.ITableOutputComponent;
 import com.queryeer.dialog.ValueDialog;
+import com.queryeer.dialog.ValueDialog.Format;
 
 /** The main panel that contains all the result set tables */
 class TableOutputComponent extends JPanel implements ITableOutputComponent, SearchListener
@@ -69,7 +77,7 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
     private final IQueryFile queryFile;
     private final TableActionsConfigurable tableActionsConfigurable;
     private final List<ITableContextMenuActionFactory> contextMenuActionFactories;
-    private final List<Table> tables = new ArrayList<>();
+    private final List<TableComponent> tables = new ArrayList<>();
     private final TableFindDialog findDialog;
     private final IOutputExtension extension;
 
@@ -77,6 +85,56 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
     private Table lastClickedTable;
     private int lastClickedTableRow;
     private int lastClickedTableColumn;
+
+    class TableComponent extends JPanel
+    {
+        private final Table table;
+
+        TableComponent(Table table, Map<String, Object> resultMetaData)
+        {
+            this.table = table;
+            setLayout(new BorderLayout());
+
+            // Add meta data panel on top of table if present
+            if (!MapUtils.isEmpty(resultMetaData))
+            {
+                JPanel metaPanel = new JPanel(new GridBagLayout());
+                // Restrict the height
+                metaPanel.setMaximumSize(new Dimension(100, 18));
+
+                JTextField value = new JTextField();
+                value.setBackground(Color.WHITE);
+                value.setEditable(false);
+                value.setText(resultMetaData.entrySet()
+                        .stream()
+                        .map(e -> e.getKey() + ": " + e.getValue())
+                        .collect(joining(", ")));
+
+                GridBagConstraints gbc = new GridBagConstraints();
+                gbc.gridx = 0;
+                gbc.gridy = 0;
+                gbc.weightx = 1.0d;
+                gbc.anchor = GridBagConstraints.WEST;
+                gbc.fill = GridBagConstraints.HORIZONTAL;
+
+                metaPanel.add(value, gbc);
+
+                JButton showValue = new JButton("...");
+                showValue.addActionListener(l -> ValueDialog.showValueDialog("Result Set Meta Data", resultMetaData, Format.JSON));
+
+                gbc = new GridBagConstraints();
+                gbc.gridx = 1;
+                gbc.gridy = 0;
+                gbc.anchor = GridBagConstraints.WEST;
+                gbc.fill = GridBagConstraints.NONE;
+
+                metaPanel.add(showValue, gbc);
+
+                add(metaPanel, BorderLayout.NORTH);
+            }
+            add(new JScrollPane(table), BorderLayout.CENTER);
+        }
+    }
 
     TableOutputComponent(IQueryFile queryFile, IOutputExtension extension, List<ITableContextMenuActionFactory> contextMenuActionFactories, TableActionsConfigurable tableActionsConfigurable)
     {
@@ -165,7 +223,7 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
                 int tableIndex = 0;
                 for (int i = 0; i < tables.size(); i++)
                 {
-                    Table table = tables.get(i);
+                    TableComponent table = tables.get(i);
                     if (table == findDialog.currentTable)
                     {
                         tableIndex = i;
@@ -180,9 +238,9 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
                     int startCol = findDialog.currentCol;
                     for (int i = tableIndex; i < tables.size(); i++)
                     {
-                        Table table = tables.get(i);
-                        int rowCount = table.getRowCount();
-                        int colCount = table.getColumnCount();
+                        TableComponent tc = tables.get(i);
+                        int rowCount = tc.table.getRowCount();
+                        int colCount = tc.table.getColumnCount();
 
                         for (int row = startRow; row < rowCount; row++)
                         {
@@ -194,22 +252,22 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
                                     continue;
                                 }
 
-                                Object value = table.getValueAt(row, col);
+                                Object value = tc.table.getValueAt(row, col);
                                 if (!match(value, context, pattern))
                                 {
                                     continue;
                                 }
 
                                 // Mark for next find
-                                findDialog.currentTable = table;
+                                findDialog.currentTable = tc;
                                 findDialog.currentRow = row;
                                 findDialog.currentCol = col;
 
-                                Rectangle bounds = new Rectangle(table.getBounds());
-                                table.scrollRectToVisible(bounds);
+                                Rectangle bounds = new Rectangle(tc.table.getBounds());
+                                tc.table.scrollRectToVisible(bounds);
 
-                                table.changeSelection(row, col, false, false);
-                                table.scrollRectToVisible(new Rectangle(table.getCellRect(row, col, true)));
+                                tc.table.changeSelection(row, col, false, false);
+                                tc.table.scrollRectToVisible(new Rectangle(tc.table.getCellRect(row, col, true)));
                                 return;
                             }
                             startCol = 0;
@@ -259,11 +317,11 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
         findDialog.currentTable = null;
 
         // Remove listeners
-        for (JTable table : tables)
+        for (TableComponent tc : tables)
         {
-            table.setTableHeader(null);
-            Model model = (Model) table.getModel();
-            model.removeTableModelListener(table);
+            tc.table.setTableHeader(null);
+            Model model = (Model) tc.table.getModel();
+            model.removeTableModelListener(tc.table);
         }
 
         tables.clear();
@@ -280,7 +338,7 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
     @Override
     public void selectRow(int tableIndex, int row)
     {
-        Table table = tables.get(tableIndex);
+        Table table = tables.get(tableIndex).table;
 
         Rectangle bounds = new Rectangle(table.getBounds());
         table.scrollRectToVisible(bounds);
@@ -559,7 +617,7 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
     }
 
     /** Add new result set to this instance */
-    synchronized void addResult(final Model model)
+    synchronized void addResult(final Model model, Map<String, Object> resultMetaData)
     {
         final Table resultTable = createTable();
         model.addTableModelListener(e ->
@@ -582,29 +640,30 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
         {
             resizeLastTablesColumns();
         }
-        tables.add(resultTable);
+        tables.add(new TableComponent(resultTable, resultMetaData));
         int size = tables.size();
         removeAll();
 
         // 8 rows plus header plus spacing
-        int tablHeight = resultTable.getRowHeight() * 9 + 10;
+        int tablHeight = resultTable.getRowHeight() * 9 + 10 + (!MapUtils.isEmpty(resultMetaData) ? 18
+                : 0);
 
         Component parent = null;
 
         for (int i = 0; i < size; i++)
         {
-            JTable table = tables.get(i);
-            JTable prevTable = i > 0 ? tables.get(i - 1)
+            TableComponent table = tables.get(i);
+            TableComponent prevTable = i > 0 ? tables.get(i - 1)
                     : null;
             int prevTableHeight = -1;
             if (i > 0)
             {
-                JScrollBar horizontalScrollBar = ((JScrollPane) prevTable.getParent()
+                JScrollBar horizontalScrollBar = ((JScrollPane) prevTable.table.getParent()
                         .getParent()).getHorizontalScrollBar();
 
                 // The least of 8 rows or actual rows in prev table
                 // CSOFF
-                prevTableHeight = Math.min((prevTable.getRowCount() + 1) * prevTable.getRowHeight() + 15, tablHeight);
+                prevTableHeight = Math.min((prevTable.table.getRowCount() + 1) * prevTable.table.getRowHeight() + 15 + prevTable.getHeight(), tablHeight);
                 // CSON
                 if (horizontalScrollBar.isVisible())
                 {
@@ -622,11 +681,11 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
                 JSplitPane sp = new JSplitPane();
                 sp.setBorder(BorderFactory.createEmptyBorder());
                 sp.setOrientation(JSplitPane.VERTICAL_SPLIT);
-                sp.setLeftComponent(new JScrollPane(parent));
+                sp.setLeftComponent(parent);
                 // Adjust prev tables height
                 sp.getLeftComponent()
                         .setPreferredSize(new Dimension(0, prevTableHeight));
-                sp.setRightComponent(new JScrollPane(table));
+                sp.setRightComponent(table);
                 sp.getRightComponent()
                         .setPreferredSize(new Dimension(0, tablHeight));
 
@@ -643,11 +702,9 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
                 sp.setOrientation(JSplitPane.VERTICAL_SPLIT);
 
                 // Adjust prev tables height
-                if (rc instanceof JScrollPane)
+                if (rc instanceof TableComponent)
                 {
-                    JScrollPane scrollPane = new JScrollPane(prevTable);
-                    scrollPane.setBorder(BorderFactory.createEmptyBorder());
-                    sp.setLeftComponent(scrollPane);
+                    sp.setLeftComponent(prevTable);
                     sp.getLeftComponent()
                             .setPreferredSize(new Dimension(0, prevTableHeight));
                 }
@@ -657,9 +714,7 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
                             .setPreferredSize(new Dimension(0, prevTableHeight));
                     sp.setLeftComponent(rc);
                 }
-                JScrollPane scrollPane = new JScrollPane(table);
-                scrollPane.setBorder(BorderFactory.createEmptyBorder());
-                sp.setRightComponent(scrollPane);
+                sp.setRightComponent(table);
                 sp.getRightComponent()
                         .setPreferredSize(new Dimension(0, tablHeight));
 
@@ -670,25 +725,19 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
                 prevSp.setRightComponent(sp);
             }
         }
-        add(new JScrollPane(parent), BorderLayout.CENTER);
+        add(parent instanceof JSplitPane ? new JScrollPane(parent)
+                : parent, BorderLayout.CENTER);
     }
 
     void resizeLastTablesColumns()
     {
         // Resize last columns if not already done
         if (tables.size() > 0
-                && !tables.get(tables.size() - 1).columnsAdjusted.get())
+                && !tables.get(tables.size() - 1).table.columnsAdjusted.get())
         {
-            Table lastTable = tables.get(tables.size() - 1);
+            Table lastTable = tables.get(tables.size() - 1).table;
             lastTable.adjustColumns();
         }
-    }
-
-    int getTotalRowCount()
-    {
-        return tables.stream()
-                .mapToInt(JTable::getRowCount)
-                .sum();
     }
 
     private static class TableSelectedRow implements SelectedRow
@@ -772,7 +821,7 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
 
     private class TableFindDialog extends FindDialog
     {
-        private Table currentTable;
+        private TableComponent currentTable;
         private int currentCol;
         private int currentRow;
         private boolean initialSearch = true;
@@ -807,11 +856,11 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
                 return;
             }
             currentCol++;
-            if (currentCol >= currentTable.getColumnCount())
+            if (currentCol >= currentTable.table.getColumnCount())
             {
                 currentCol = 0;
                 currentRow++;
-                if (currentRow >= currentTable.getRowCount())
+                if (currentRow >= currentTable.table.getRowCount())
                 {
                     currentRow = 0;
 
@@ -834,13 +883,13 @@ class TableOutputComponent extends JPanel implements ITableOutputComponent, Sear
                 currentCol = 0;
                 initialSearch = true;
                 // Start search from current selection
-                for (Table table : tables)
+                for (TableComponent tc : tables)
                 {
-                    if (table.hasFocus())
+                    if (tc.table.hasFocus())
                     {
-                        currentTable = table;
-                        currentRow = table.getSelectedRow();
-                        currentCol = table.getSelectedColumn();
+                        currentTable = tc;
+                        currentRow = tc.table.getSelectedRow();
+                        currentCol = tc.table.getSelectedColumn();
                         break;
                     }
                 }

--- a/queryeer-ide/src/main/java/com/queryeer/output/table/TableOutputWriter.java
+++ b/queryeer-ide/src/main/java/com/queryeer/output/table/TableOutputWriter.java
@@ -19,11 +19,10 @@ import javax.swing.SwingUtilities;
 import org.apache.commons.io.IOUtils;
 
 import com.queryeer.api.IQueryFile;
-
-import se.kuseman.payloadbuilder.api.OutputWriter;
+import com.queryeer.api.extensions.output.QueryeerOutputWriter;
 
 /** Writer that writes object structure from a projection. */
-class TableOutputWriter implements OutputWriter
+class TableOutputWriter implements QueryeerOutputWriter
 {
     /** Current model */
     private Model model;
@@ -38,7 +37,7 @@ class TableOutputWriter implements OutputWriter
     private final Deque<String> currentField = new ArrayDeque<>();
 
     @Override
-    public void initResult(String[] columns)
+    public void initResult(String[] columns, Map<String, Object> resultMetaData)
     {
         // Print previous model row count
         if (model != null)
@@ -53,7 +52,7 @@ class TableOutputWriter implements OutputWriter
         // Need a sync call here else we will have races on fast queries where we append wrong models
         try
         {
-            SwingUtilities.invokeAndWait(() -> getTablesOutputComponent().addResult(model));
+            SwingUtilities.invokeAndWait(() -> getTablesOutputComponent().addResult(model, resultMetaData));
         }
         catch (InvocationTargetException | InterruptedException e)
         {


### PR DESCRIPTION
…tWriter to be able to receive metadata about a result set.

This is implemented on TableOutputWriter and used ju JdbcQuery engine to print a description text above each result set with information about which connection/database etc. the result set was originating from.

fix: Fix issue where abort flag was set prior to executing in JdbcQueryEngine which made the query return 0 rows even if there was rows.
fix: Refactor out JdbcQueryEngines quick properties to an own class
fix: Set taskbar icon to get a dock icon on OSX