### PR TITLE
feat: Use io.methvin directory watcher on OSX to avoid high CPU usage…

### DIFF
--- a/queryeer-ide/pom.xml
+++ b/queryeer-ide/pom.xml
@@ -27,6 +27,7 @@
         <jgraphx.version> 3.4.1.3</jgraphx.version>
         <l2fprod-properties-editor.version>1.3.0</l2fprod-properties-editor.version>
         <flatlaf.version>3.5.4</flatlaf.version>
+        <directory-watcher.version>0.19.0</directory-watcher.version>
     </properties>
 
     <dependencies>
@@ -77,6 +78,11 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <version>${freemarker.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.methvin</groupId>
+            <artifactId>directory-watcher</artifactId>
+            <version>${directory-watcher.version}</version>
         </dependency>
 
         <!--  UI -->

--- a/queryeer-ide/src/main/java/com/queryeer/FileWatchService.java
+++ b/queryeer-ide/src/main/java/com/queryeer/FileWatchService.java
@@ -24,6 +24,11 @@ import org.apache.commons.lang3.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.queryeer.api.utils.OsUtils;
+
+import io.methvin.watchservice.MacOSXListeningWatchService;
+import io.methvin.watchservice.WatchablePath;
+
 /** Watch service that wraps {@link Watchable} with a callback style api. */
 class FileWatchService
 {
@@ -45,8 +50,23 @@ class FileWatchService
         WatchService watchService = null;
         try
         {
-            watchService = FileSystems.getDefault()
-                    .newWatchService();
+            if (OsUtils.isMacOsx())
+            {
+                try
+                {
+                    watchService = new MacOSXListeningWatchService();
+                }
+                catch (Throwable t)
+                {
+                    LOGGER.error("Error creating a MacOSX Watch service, falling back to JDK default. Check library path", t);
+                }
+            }
+
+            if (watchService == null)
+            {
+                watchService = FileSystems.getDefault()
+                        .newWatchService();
+            }
         }
         catch (IOException e)
         {
@@ -208,7 +228,9 @@ class FileWatchService
         try
         {
             LOGGER.trace("Register {}", path);
-            return path.register(watchService, StandardWatchEventKinds.OVERFLOW, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
+            Watchable watchable = OsUtils.isMacOsx() ? new WatchablePath(path)
+                    : path;
+            return watchable.register(watchService, StandardWatchEventKinds.OVERFLOW, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
         }
         catch (IOException e)
         {


### PR DESCRIPTION
… that exists in default JDK poller